### PR TITLE
Resolve namespace ambiguities

### DIFF
--- a/include/nanofmt/format.inl
+++ b/include/nanofmt/format.inl
@@ -118,20 +118,20 @@ namespace NANOFMT_NS {
     }
 
     constexpr format_output& format_output::put(char ch) noexcept {
-        pos = NANOFMT_NS::put(pos, end, ch);
+        pos = ::NANOFMT_NS::put(pos, end, ch);
         ++advance;
         return *this;
     }
 
     constexpr format_output& format_output::fill_n(char ch, std::size_t count) noexcept {
-        pos = NANOFMT_NS::fill_n(pos, end, ch, count);
+        pos = ::NANOFMT_NS::fill_n(pos, end, ch, count);
         advance += count;
         return *this;
     }
 
     template <typename... Args>
     format_output& format_output::format(format_string fmt, Args const&... args) {
-        return *this = detail::vformat(*this, fmt, NANOFMT_NS::make_format_args(args...));
+        return *this = detail::vformat(*this, fmt, ::NANOFMT_NS::make_format_args(args...));
     }
 
     format_output& format_output::vformat(format_string fmt, format_args&& args) {
@@ -182,13 +182,13 @@ namespace NANOFMT_NS {
 
     template <typename... Args>
     [[nodiscard]] char* format_to_n(char* dest, std::size_t count, format_string format_str, Args const&... args) {
-        return detail::vformat(format_output{dest, dest + count}, format_str, NANOFMT_NS::make_format_args(args...))
+        return detail::vformat(format_output{dest, dest + count}, format_str, ::NANOFMT_NS::make_format_args(args...))
             .pos;
     }
 
     template <typename... Args>
     format_output& format_to(format_output& out, format_string format_str, Args const&... args) {
-        return out = detail::vformat(out, format_str, NANOFMT_NS::make_format_args(args...));
+        return out = detail::vformat(out, format_str, ::NANOFMT_NS::make_format_args(args...));
     }
 
     template <std::size_t N, typename... Args>
@@ -196,7 +196,7 @@ namespace NANOFMT_NS {
         char* const pos = detail::vformat(
                               format_output{dest, dest + (N - 1 /*NUL*/)},
                               format_str,
-                              NANOFMT_NS::make_format_args(args...))
+                              ::NANOFMT_NS::make_format_args(args...))
                               .pos;
         *pos = '\0';
         return pos;
@@ -204,7 +204,7 @@ namespace NANOFMT_NS {
 
     template <typename... Args>
     [[nodiscard]] std::size_t format_length(format_string format_str, Args const&... args) {
-        return detail::vformat(format_output{}, format_str, NANOFMT_NS::make_format_args(args...)).advance;
+        return detail::vformat(format_output{}, format_str, ::NANOFMT_NS::make_format_args(args...)).advance;
     }
 
     [[nodiscard]] std::size_t vformat_length(format_string format_str, format_args&& args) {

--- a/tests/test_format.cpp
+++ b/tests/test_format.cpp
@@ -215,8 +215,8 @@ TEST_CASE("nanofmt.format.custom", "[nanofmt][format][custom]") {
 // SECTION("errors") {
 //    char buffer[256];
 
-//    CHECK(sformat_to(buffer, "{} {:4d} {:3.5f}", "abc", 9, 12.57) == NANOFMT_NS::format_result::success);
-//    CHECK(sformat_to(buffer, "{} {:4d", "abc", 9) == NANOFMT_NS::format_result::malformed_input);
-//    CHECK(sformat_to(buffer, "{0} {1}", "abc", 9) == NANOFMT_NS::format_result::success);
-//    CHECK(sformat_to(buffer, "{0} {1} {5}", "abc", 9, 12.57) == NANOFMT_NS::format_result::out_of_range);
+//    CHECK(sformat_to(buffer, "{} {:4d} {:3.5f}", "abc", 9, 12.57) == ::NANOFMT_NS::format_result::success);
+//    CHECK(sformat_to(buffer, "{} {:4d", "abc", 9) == ::NANOFMT_NS::format_result::malformed_input);
+//    CHECK(sformat_to(buffer, "{0} {1}", "abc", 9) == ::NANOFMT_NS::format_result::success);
+//    CHECK(sformat_to(buffer, "{0} {1} {5}", "abc", 9, 12.57) == ::NANOFMT_NS::format_result::out_of_range);
 //}

--- a/tests/test_format_args.cpp
+++ b/tests/test_format_args.cpp
@@ -8,7 +8,7 @@
 namespace {
     template <typename T>
     constexpr auto to_arg(T const& value) noexcept {
-        return NANOFMT_NS::make_format_args(value).values[0];
+        return ::NANOFMT_NS::make_format_args(value).values[0];
     }
 } // namespace
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -28,7 +28,7 @@ namespace NANOFMT_NS::test {
     auto sformat(format_string fmt, ArgsT&&... args) {
         string_result<N> result;
         char const* const end =
-            NANOFMT_NS::format_to_n(result.buffer, sizeof result.buffer, fmt, std::forward<ArgsT>(args)...);
+            ::NANOFMT_NS::format_to_n(result.buffer, sizeof result.buffer, fmt, std::forward<ArgsT>(args)...);
         result.size = end - result.buffer;
         return result;
     }
@@ -37,7 +37,7 @@ namespace NANOFMT_NS::test {
     auto to_string(ValueT const& value, ArgsT&&... args) {
         string_result<N> result;
         char const* const end =
-            NANOFMT_NS::to_chars(result.buffer, result.buffer + sizeof result.buffer, value, args...);
+            ::NANOFMT_NS::to_chars(result.buffer, result.buffer + sizeof result.buffer, value, args...);
         result.size = end - result.buffer;
         return result;
     }


### PR DESCRIPTION
- Use namespace to reference `make_format_args` (avoids ambiguity with `std::make_format_args` or `fmt::make_format_args`, if those are pulled in via ADL for any reason)
- Use fully-qualified namespaces