### PR TITLE
Allow disabling use of float and double

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(NANOFMT_NS "" CACHE STRING "Namespace for nanofmt API and implementation")
 option(NANOFMT_TESTS "Build nanofmt tests" ${NANOFMT_IS_TOPLEVEL})
 option(NANOFMT_DOCS "Build sphinx and doxygen documentation" OFF)
 option(NANOFMT_INSTALL "Add install targets for nanofmt" ON)
+option(NANOFMT_FLOAT "Enable support for float and double" ON)
 
 add_library(nanofmt STATIC)
 add_library(nanofmt::nanofmt ALIAS nanofmt)
@@ -24,6 +25,10 @@ target_include_directories(nanofmt
         $<INSTALL_INTERFACE:include>
 )
 target_compile_features(nanofmt PUBLIC cxx_std_17)
+
+if (NANOFMT_FLOAT)
+    target_compile_definitions(nanofmt PUBLIC -DNANOFMT_FLOAT=1)
+endif()
 
 if (NANOFMT_NS)
     target_compile_definitions(nanofmt PUBLIC -DNANOFMT_NS=${NANOFMT_NS})

--- a/include/nanofmt/config.h
+++ b/include/nanofmt/config.h
@@ -4,6 +4,10 @@
 #define NANOFMT_CONFIG_H_ 1
 #pragma once
 
+#if !defined(NANOFMT_FLOAT)
+#    define NANOFMT_FLOAT 1
+#endif
+
 #if !defined(NANOFMT_NS)
 #    define NANOFMT_NS nanofmt
 #endif

--- a/include/nanofmt/format.h
+++ b/include/nanofmt/format.h
@@ -209,10 +209,12 @@ namespace NANOFMT_NS {
     template <>
     struct formatter<unsigned long long> : detail::default_formatter<unsigned long long> {};
 
+#if NANOFMT_FLOAT
     template <>
     struct formatter<float> : detail::default_formatter<float> {};
     template <>
     struct formatter<double> : detail::default_formatter<double> {};
+#endif
 
     template <>
     struct formatter<decltype(nullptr)> : detail::default_formatter<void const*> {};

--- a/source/charconv.cpp
+++ b/source/charconv.cpp
@@ -54,12 +54,14 @@ namespace NANOFMT_NS::detail {
         int exponent,
         int precision) noexcept;
 
+#if NANOFMT_FLOAT
     static char* to_chars_impl_nonfinite(
         char* dest,
         char const* end,
         bool negative,
         bool infinite,
         bool upper) noexcept;
+#endif
 
     // maximum significand for double is 17 decimal digits
     static constexpr size_t significand_max_digits10 = 17;
@@ -106,6 +108,7 @@ namespace NANOFMT_NS {
         return detail::to_chars_impl(dest, end, value, fmt);
     }
 
+#if NANOFMT_FLOAT
     char* to_chars(char* dest, char const* end, float value, float_format fmt) noexcept {
         return detail::to_chars_impl<std::uint32_t>(dest, end, value, fmt, -1);
     }
@@ -121,6 +124,7 @@ namespace NANOFMT_NS {
     char* to_chars(char* dest, char const* end, double value, float_format fmt, int precision) noexcept {
         return detail::to_chars_impl<std::uint64_t>(dest, end, value, fmt, precision);
     }
+#endif
 
     template <typename IntegerT>
     char* detail::to_chars_impl(char* dest, char const* end, IntegerT value, int_format fmt) noexcept {
@@ -539,6 +543,7 @@ namespace NANOFMT_NS {
         return to_chars_impl_scientific<E, /*TrailingZeroes=*/false>(dest, end, significand, exponent, P - 1);
     }
 
+#if NANOFMT_FLOAT
     char* detail::to_chars_impl_nonfinite(
         char* dest,
         char const* end,
@@ -553,4 +558,5 @@ namespace NANOFMT_NS {
         }
         return copy_to(dest, end, upper ? "NAN" : "nan");
     }
+#endif
 } // namespace NANOFMT_NS

--- a/source/format.cpp
+++ b/source/format.cpp
@@ -22,7 +22,9 @@ namespace NANOFMT_NS {
             format_spec const& spec) noexcept;
         static constexpr int_format select_int_format(char type) noexcept;
         static constexpr char const* parse_int_spec(char const* in, char const* end, format_spec& spec) noexcept;
+#if NANOFMT_FLOAT
         static constexpr char const* parse_float_spec(char const* in, char const* end, format_spec& spec) noexcept;
+#endif
         static constexpr std::size_t strnlen(char const* string, std::size_t max_length) noexcept;
         static void format_char_impl(char value, format_output& out, format_spec const& spec) noexcept;
         template <typename IntT>
@@ -106,6 +108,7 @@ namespace NANOFMT_NS {
         return format_int_impl(value, out, spec);
     }
 
+#if NANOFMT_FLOAT
     template <>
     char const* detail::default_formatter<float>::parse(char const* in, char const* end) noexcept {
         return parse_float_spec(in, end, spec);
@@ -125,6 +128,7 @@ namespace NANOFMT_NS {
     void detail::default_formatter<double>::format(double value, format_output& out) noexcept {
         return format_float_impl(value, out, spec);
     }
+#endif
 
     template <>
     char const* detail::default_formatter<bool>::parse(char const* in, char const* end) noexcept {
@@ -294,10 +298,12 @@ namespace NANOFMT_NS {
                 return invoke(value.v_longlong);
             case types::t_ulonglong:
                 return invoke(value.v_ulonglong);
+#if NANOFMT_FLOAT
             case types::t_float:
                 return invoke(value.v_float);
             case types::t_double:
                 return invoke(value.v_double);
+#endif
             case types::t_bool:
                 return invoke(value.v_bool);
             case types::t_cstring:
@@ -306,6 +312,8 @@ namespace NANOFMT_NS {
                 return invoke(value.v_voidptr);
             case types::t_custom:
                 return value.v_custom.thunk(value.v_custom.value, in, end, out);
+            default:
+                break;
         }
     }
 
@@ -490,9 +498,11 @@ namespace NANOFMT_NS {
         return parse_spec(in, end, spec, "bBcdoxX");
     }
 
+#if NANOFMT_FLOAT
     constexpr char const* detail::parse_float_spec(char const* in, char const* end, format_spec& spec) noexcept {
         return parse_spec(in, end, spec, "aAeEfFgG");
     }
+#endif
 
     constexpr std::size_t detail::strnlen(char const* string, std::size_t max_length) noexcept {
         for (std::size_t length = 0; length != max_length; ++length) {


### PR DESCRIPTION
Allow defining NANOFMT_FLOAT to eather 1 or 0 to enable and disable support for floating point numbers