### PR TITLE
Mark Catch2 dependency as SYSTEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(nanofmt VERSION 0.1 LANGUAGES CXX)
 cmake_minimum_required(VERSION 3.25)
+project(nanofmt VERSION 0.1 LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.16)
 project(nanofmt VERSION 0.1 LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.25)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/cmake/fetch_catch2.cmake
+++ b/cmake/fetch_catch2.cmake
@@ -2,6 +2,7 @@ include(FetchContent)
 
 FetchContent_Declare(
     Catch2
+    SYSTEM
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     GIT_TAG        v3.5.1
 )


### PR DESCRIPTION
Bumps CMake requirement to 3.25